### PR TITLE
Curl support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,7 @@ target_link_libraries(
 )
 set(proxyme_templates 	templates/proxyme.ini
 						templates/apt.tpl
+						templates/curl.tpl
 						templates/git.tpl
 						templates/subversion.tpl
 						templates/wget.tpl

--- a/templates/curl.tpl
+++ b/templates/curl.tpl
@@ -1,0 +1,4 @@
+# {{PROXYME}}
+{{#PROXY}}
+proxy=http://{{#PROXY_AUTH}}{{PROXY_USER}}:{{PROXY_PWD}}@{{/PROXY_AUTH}}{{PROXY_HOST}}:{{PROXY_PORT}}
+{{/PROXY}}

--- a/templates/proxyme.ini
+++ b/templates/proxyme.ini
@@ -9,6 +9,10 @@
 	template=$(HOME)/.proxyme/wget.tpl
 	target=$(HOME)/.wgetrc
 
+[curl]
+	template=$(HOME)/.proxyme/curl.tpl
+	target=$(HOME)/.curlrc
+
 [subversion]
 	template=$(HOME)/.proxyme/subversion.tpl
 	target=$(HOME)/.subversion/servers


### PR DESCRIPTION
Proxyme now supports curl along wget. This allows tools that use curl to work behind a proxy.
